### PR TITLE
Initial scripts to be run during auto deployment

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -88,13 +88,13 @@ files:
   #     runas:
 # During the BeforeInstall deployment lifecycle event, run the commands
 #   in the script specified in "location".
-  # BeforeInstall:
-  #   - location:
-  #     timeout:
-  #     runas:
-  #   - location:
-  #     timeout:
-  #     runas:
+  BeforeInstall:
+    - location: /home/ec2-user/app/codeDeployScripts/removePreviousBuild.sh
+      timeout: 30
+      runas: ec2-user
+    # - location:
+    #   timeout:
+    #   runas:
 # During the AfterInstall deployment lifecycle event, run the commands
 #   in the script specified in "location".
   # AfterInstall:
@@ -106,10 +106,10 @@ files:
   #     runas:
 # During the ApplicationStart deployment lifecycle event, run the commands
 #   in the script specified in "location".
-  # ApplicationStart:
-  #   - location:
-  #     timeout:
-  #     runas:
+  ApplicationStart:
+    - location: /home/ec2-user/app/codeDeployScripts/buildAndRunDeployment.sh
+      timeout: 150
+      runas: ec2-user
   #   - location:
   #     timeout:
   #     runas:

--- a/codeDeployScripts/buildAndRunDeployment.sh
+++ b/codeDeployScripts/buildAndRunDeployment.sh
@@ -1,0 +1,3 @@
+cd /home/ec2-user/app
+npm install
+npm run start

--- a/codeDeployScripts/removePreviousBuild.sh
+++ b/codeDeployScripts/removePreviousBuild.sh
@@ -1,0 +1,4 @@
+cd /home/ec2-user/app
+rm -rfv /home/ec2-user/app/*
+ls
+printf "Cleaned app directory for new build install"


### PR DESCRIPTION
Two scripts:
- One for deleting the old build from the app directory in our EC2 CodeDeploy instance, so there aren't problems from having multiple project builds in the same directory as well as to keep our EC2 clean.
- One for installing npm packages once the new build is installed and running our "start" script.
Both scripts were then specified to run at certain points of the automated deployment process within appspec.yml.