### PR TITLE
Remove .login .signup from styles.scss, navbar Home

### DIFF
--- a/positive_charge/src/components/navbar.jsx
+++ b/positive_charge/src/components/navbar.jsx
@@ -39,6 +39,10 @@ const ResponsiveAppBar = ({ isLoggedIn, logOut }) => {
     setAnchorElUser(null);
   };
 
+  const handleClickHome = () => {
+    navigate('/');
+  }
+
   const handleLogin = () => {
     navigate('/login');
   }
@@ -134,7 +138,7 @@ const ResponsiveAppBar = ({ isLoggedIn, logOut }) => {
               }}
             >
               {pages.map((page) => (
-                <MenuItem key={page} onClick={handleCloseNavMenu}>
+                <MenuItem key={page} onClick={page === 'Home' ? handleClickHome : handleCloseNavMenu}>
                   <Typography textAlign="center">{page}</Typography>
                 </MenuItem>
               ))}

--- a/positive_charge/src/styles.scss
+++ b/positive_charge/src/styles.scss
@@ -315,19 +315,19 @@ Add POI Component
     height: 100%;
   }
 
-  .login{
+  // .login{
 
-    float: right;
-    height: auto;
-    margin-right: 10%;
-  }
+  //   float: right;
+  //   height: auto;
+  //   margin-right: 10%;
+  // }
 
-  .signup{
+  // .signup{
 
-    float: right;
-    height: 100%;
-    margin-right: 5%;
-  }
+  //   float: right;
+  //   height: 100%;
+  //   margin-right: 5%;
+  // }
 
   .seePOIListHeader{
 


### PR DESCRIPTION
.login and .signup affect the actual login and signup components, commenting those out of styles.scss.
Attempted to add function to navigate to '/' on Home button, it does not behave consistently.